### PR TITLE
Fix bug where execution flag was incorrectly autodetected

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,9 @@
 {
-  "extends": "airbnb-base"
+  "extends": "airbnb-base",
+  "env": {
+    "mocha": true
+  },
+  "rules": {
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": true}]
+  }
 }

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 > Spawn shell command with platform default shell
 
-[![Build Status](https://travis-ci.org/kimmobrunfeldt/spawn-default-shell.svg?branch=master)](https://travis-ci.org/kimmobrunfeldt/spawn-default-shell)
+[![Build Status](https://travis-ci.org/kimmobrunfeldt/spawn-default-shell.svg?branch=master)](https://travis-ci.org/kimmobrunfeldt/spawn-default-shell) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/kimmobrunfeldt/spawn-default-shell?branch=master&svg=true)](https://ci.appveyor.com/project/kimmobrunfeldt/spawn-default-shell) *master branch status*
 
 [![NPM Badge](https://nodei.co/npm/spawn-default-shell.png?downloads=true)](https://www.npmjs.com/package/spawn-default-shell)
 
 Like `child_process.spawn` with `shell: true` option but a bit more
-convenient and customizable. You can just pass the command as a string, 
+convenient and customizable. You can just pass the command as a string,
 and it will be executed in the platform default shell.
 
 ```js

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,4 @@ build: off
 test_script:
   - node --version
   - npm --version
-  - set SHELL=cmd.exe
-  - set SHELL_EXECUTE_FLAG=/c
   - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,5 +13,5 @@ test_script:
   - node --version
   - npm --version
   - set SHELL=cmd.exe
-  - set SHELL_EXECUTION_FLAG=/c
+  - set SHELL_EXECUTE_FLAG=/c
   - npm test

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "releasor": "^1.2.1"
   },
   "scripts": {
-    "test": "mocha",
+    "test": "npm run test-debug-print && mocha",
+    "test-debug-print": "node -e \"var a = require('./src/get-shell')(); console.log('> getShell()\\n' + JSON.stringify(a, null, 2));\"",
     "lint": "eslint ./src ./test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint": "^3.5.0",
     "eslint-config-airbnb-base": "^7.1.0",
     "eslint-plugin-import": "^1.15.0",
+    "lodash": "^4.16.2",
     "mocha": "^3.0.2",
     "releasor": "^1.2.1"
   },

--- a/src/get-shell.js
+++ b/src/get-shell.js
@@ -26,7 +26,7 @@ function detectExecuteFlag(shell) {
     return '-c';
   }
 
-  throw new Error('Unable to detect platform shell type.');
+  throw new Error('Unable to detect platform shell type. Please set SHELL_EXECUTE_FLAG env variable.');
 }
 
 function getShell() {

--- a/src/get-shell.js
+++ b/src/get-shell.js
@@ -1,23 +1,40 @@
-function getShell() {
-  const env = process.env;
+const DETECT_CMD_REGEX = /cmd.exe/;
+// All sh variant names I found end with "sh":
+// https://en.wikipedia.org/wiki/List_of_command-line_interpreters
+const DETECT_SH_REGEX = /sh$/;
 
+function detectPlatformShell() {
   if (process.platform === 'darwin') {
-    return {
-      shell: env.SHELL || '/bin/bash',
-      executeFlag: env.SHELL_EXECUTE_FLAG || '-c',
-    };
+    return process.env.SHELL || '/bin/bash';
   }
 
   if (process.platform === 'win32') {
-    return {
-      shell: env.SHELL || env.COMSPEC || 'cmd.exe',
-      executeFlag: env.SHELL_EXECUTE_FLAG || '/c',
-    };
+    return process.env.SHELL || process.env.COMSPEC || 'cmd.exe';
   }
 
+  return process.env.SHELL || '/bin/sh';
+}
+
+function detectExecuteFlag(shell) {
+  if (process.env.SHELL_EXECUTE_FLAG) {
+    return process.env.SHELL_EXECUTE_FLAG;
+  }
+
+  if (shell.match(DETECT_CMD_REGEX)) {
+    return '/c';
+  } else if (shell.match(DETECT_SH_REGEX)) {
+    return '-c';
+  }
+
+  throw new Error('Unable to detect platform shell type.');
+}
+
+function getShell() {
+  const shell = detectPlatformShell();
+
   return {
-    shell: env.SHELL || '/bin/sh',
-    executeFlag: env.SHELL_EXECUTE_FLAG || '-c',
+    shell: shell,
+    executeFlag: detectExecuteFlag(shell),
   };
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,5 +12,5 @@ function spawn(command, spawnOpts) {
 }
 
 module.exports = {
-  spawn: spawn
+  spawn: spawn,
 };

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -1,19 +1,26 @@
-const assert = require('assert');
-const defaultShell = require('../src/index');
+const _ = require('lodash');
+const testBasic = require('./test-basic');
+const testPlatformShared = require('./test-platform-shared');
+
+const PLATFORMS = ['darwin', 'freebsd', 'linux', 'sunos', 'win32'];
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
 
 describe('spawn-default-shell', () => {
-  it('piping should work', (done) => {
-    const child = defaultShell.spawn('cat test/data/test.txt | grep 1', {
-      stdio: 'pipe',
-    });
+  testBasic();
+});
 
-    child.stdout.on('data', (data) => {
-      assert.strictEqual(data.toString('utf8'), '1 äö☃\n');
-    });
+describe('shared tests on each platform (mocking)', () => {
+  _.each(PLATFORMS, (platform) => {
+    describe(`process.platform = "${platform}"`, () => {
+      before(() => {
+        Object.defineProperty(process, 'platform', { value: platform });
+      });
 
-    child.on('close', (code) => {
-      assert.strictEqual(code, 0);
-      done();
+      after(() => {
+        Object.defineProperty(process, 'platform', originalPlatform);
+      });
+
+      testPlatformShared();
     });
   });
 });

--- a/test/test-basic.js
+++ b/test/test-basic.js
@@ -22,7 +22,7 @@ function testBasic() {
   });
 
   it('&& operator should work', (done) => {
-    const child = defaultShell.spawn('echo 1 && return 42');
+    const child = defaultShell.spawn('echo 1 && node -e "process.exit(42)"');
 
     child.on('close', (code) => {
       assert.strictEqual(code, 42);

--- a/test/test-basic.js
+++ b/test/test-basic.js
@@ -1,0 +1,105 @@
+const assert = require('assert');
+const defaultShell = require('../src/index');
+const getShell = require('../src/get-shell');
+const { withEnv } = require('./utils');
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+
+function testBasic() {
+  it('piping should work', (done) => {
+    const child = defaultShell.spawn('cat test/data/test.txt | grep 1', {
+      stdio: 'pipe',
+    });
+
+    child.stdout.on('data', (data) => {
+      assert.strictEqual(data.toString('utf8'), '1 äö☃\n');
+    });
+
+    child.on('close', (code) => {
+      assert.strictEqual(code, 0);
+      done();
+    });
+  });
+
+  it('&& operator should work', (done) => {
+    const child = defaultShell.spawn('echo 1 && return 42');
+
+    child.on('close', (code) => {
+      assert.strictEqual(code, 42);
+      done();
+    });
+  });
+
+  describe('process.platform = "darwin"', () => {
+    before(() => {
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+    });
+
+    after(() => {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    });
+
+    it('shell resolution order should be 1. SHELL 2. /bin/bash', () => {
+      withEnv({ SHELL: '' }, () => {
+        assert.strictEqual(getShell().shell, '/bin/bash');
+        assert.strictEqual(getShell().executeFlag, '-c');
+      });
+
+      withEnv({ SHELL: 'zsh' }, () => {
+        assert.strictEqual(getShell().shell, 'zsh');
+        assert.strictEqual(getShell().executeFlag, '-c');
+      });
+    });
+  });
+
+  describe('process.platform = "win32"', () => {
+    before(() => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+    });
+
+    after(() => {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    });
+
+    it('shell resolution order should be 1. SHELL 2. COMSPEC 3. cmd.exe', () => {
+      withEnv({ SHELL: '', COMSPEC: '' }, () => {
+        assert.strictEqual(getShell().shell, 'cmd.exe');
+        assert.strictEqual(getShell().executeFlag, '/c');
+      });
+
+      withEnv({ SHELL: '', COMSPEC: '\\C:\\cmd.exe' }, () => {
+        assert.strictEqual(getShell().shell, '\\C:\\cmd.exe');
+        assert.strictEqual(getShell().executeFlag, '/c');
+      });
+
+      withEnv({ SHELL: 'bash', COMSPEC: '\\C:\\cmd.exe' }, () => {
+        assert.strictEqual(getShell().shell, 'bash');
+        assert.strictEqual(getShell().executeFlag, '-c');
+      });
+    });
+  });
+
+  describe('process.platform = "linux" (other than win32 or darwin)', () => {
+    before(() => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+    });
+
+    after(() => {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    });
+
+    it('shell resolution order should be 1. SHELL 2. /bin/sh', () => {
+      withEnv({ SHELL: '' }, () => {
+        assert.strictEqual(getShell().shell, '/bin/sh');
+        assert.strictEqual(getShell().executeFlag, '-c');
+      });
+
+      withEnv({ SHELL: 'zsh' }, () => {
+        assert.strictEqual(getShell().shell, 'zsh');
+        assert.strictEqual(getShell().executeFlag, '-c');
+      });
+    });
+  });
+}
+
+module.exports = testBasic;

--- a/test/test-basic.js
+++ b/test/test-basic.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const defaultShell = require('../src/index');
 const getShell = require('../src/get-shell');
-const { withEnv } = require('./utils');
+const withEnv = require('./utils').withEnv;
 
 const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
 

--- a/test/test-platform-shared.js
+++ b/test/test-platform-shared.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+const defaultShell = require('../src/index');
+const getShell = require('../src/get-shell');
+const { withEnv } = require('./utils');
+
+function sharedTests() {
+  it('custom /bin/zsh shell should work', () => {
+    withEnv({ SHELL: '/bin/zsh' }, () => {
+      assert.strictEqual(getShell().shell, '/bin/zsh');
+      assert.strictEqual(getShell().executeFlag, '-c');
+    });
+  });
+
+  it('custom execute flag should override default', () => {
+    withEnv({ SHELL_EXECUTE_FLAG: '--execute' }, () => {
+      assert.strictEqual(getShell().executeFlag, '--execute');
+    });
+  });
+
+  it('customizing whole command should work', () => {
+    withEnv({ SHELL: '/bin/verycustomshell', SHELL_EXECUTE_FLAG: '-x' }, () => {
+      assert.strictEqual(getShell().shell, '/bin/verycustomshell');
+      assert.strictEqual(getShell().executeFlag, '-x');
+    });
+  });
+
+  it('unknown shell without execution flag should throw error', () => {
+    withEnv({ SHELL: '/bin/false' }, () => {
+      assert.throws(
+        () => {
+          defaultShell.spawn('echo test');
+        },
+        /Unable to detect platform shell type/
+      );
+    });
+  });
+}
+
+module.exports = sharedTests;

--- a/test/test-platform-shared.js
+++ b/test/test-platform-shared.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const defaultShell = require('../src/index');
 const getShell = require('../src/get-shell');
-const { withEnv } = require('./utils');
+const withEnv = require('./utils').withEnv;
 
 function sharedTests() {
   it('custom /bin/zsh shell should work', () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,24 @@
+const _ = require('lodash');
+
+function withEnv(env, func) {
+  const originals = _.map(env, (val, key) => ({ key: key, val: process.env[key] }));
+  _.each(env, (newVal, key) => {
+    process.env[key] = newVal;
+  });
+
+  try {
+    func();
+  } finally {
+    _.each(originals, (item) => {
+      if (!item.val) {
+        delete process.env[item.key];
+      } else {
+        process.env[item.key] = item.val;
+      }
+    });
+  }
+}
+
+module.exports = {
+  withEnv: withEnv,
+};


### PR DESCRIPTION
Fixes #1 
- [x] Much bigger set of tests
- [x] Fix bug where incorrect execution flag was chosen ( #1 )
- [x] Add Appveyor for windows testing

New tests revealed unexpected behavior of cmd.exe in windows. That lead to this issue: https://github.com/kimmobrunfeldt/spawn-default-shell/issues/4. I'll leave the tests failing but meanwhile release a new version of spawn-default-shell which fixes the quite major bug #1.
